### PR TITLE
Add infos for rails in readme about usage for rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ run app
 
 ### rails usage
 
-create 
+create in the initializer folder :
 ``` ruby
 google_ajax_crawler_middleware.rb
 ```


### PR DESCRIPTION
The gem is aslo working in rails by putting the rack app in the rails middleware stack, add the way to do It in the readme
